### PR TITLE
Changing details button from graph view to table view

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can install this UI via the [provided Helm Chart](./deployments/).
 1. Clone this repository:
 
     ```bash
-    https://github.com/ArubaKube/liqo-dashboard.git
+    git clone https://github.com/ArubaKube/liqo-dashboard.git
     cd liqo-dashboard
     ```
 

--- a/frontend/src/app/modules/cluster/pages/cluster-list/cluster-list.component.html
+++ b/frontend/src/app/modules/cluster/pages/cluster-list/cluster-list.component.html
@@ -38,7 +38,7 @@
             </ng-container>
 
             <ng-container *ngIf="this.viewMode==='graph'">
-                <div *ngIf="this.selectedCluster"
+                <!-- <div *ngIf="this.selectedCluster"
                     class="z-50 bg-white absolute top-2/4 left-3/4 flex w-40 h-auto flex-col shadow-2xl">
                     <div class="flex flex-row justify-between p-2">
                         <span class="font-bold">{{this.selectedCluster.id}}</span>
@@ -51,7 +51,7 @@
                             Details
                         </button>
                     </div>
-                </div>
+                </div> -->
                 <div echarts (chartSelectChanged)="selectedChange($event)" [options]="initialChartOptions"
                     [merge]="chartOptions" class="demo-chart w-full h-full min-h-[50vh]"></div>
             </ng-container>

--- a/frontend/src/app/shared/components/cluster-table/renderer/cluster-actions-renderer.component.ts
+++ b/frontend/src/app/shared/components/cluster-table/renderer/cluster-actions-renderer.component.ts
@@ -25,8 +25,8 @@ import { Cluster } from "src/app/modules/cluster/models/cluster";
       <div class="flex">
           <button
                 routerLink="/clusters/detail/{{ data.id }}"
-                class="btn">
-            <svg-icon src="assets/icons/outline/arrow-sm-right.svg" [svgClass]="'h-5 w-5'"> </svg-icon>
+                class="bg-blue-500 hover:bg-blue-600 text-white font-medium py-2 px-4 rounded text-sm transition-colors">
+            Details
           </button>
       </div>
   `,


### PR DESCRIPTION
This PR includes a few small changes requested by Professor Risso:

Removed the "Detail" button from the pop-ups that appear when clicking on remote clusters in the Graph view.
The "Detail" functionality is now accessible only from the Table view.
Fixed a small oversight in the README.md by adding a missing command.

