### PR TITLE
Add the Offloading Policy in the offloaded namespaces table (fix #9)

### DIFF
--- a/frontend/src/app/shared/components/namespace-table/namespace-table.component.ts
+++ b/frontend/src/app/shared/components/namespace-table/namespace-table.component.ts
@@ -20,6 +20,7 @@ import { ColDef } from "ag-grid-community";
 import { Namespace } from "../../../modules/namespace/models/namespace";
 import { NamespaceActionsRendererComponent } from "./renderer/namespace-actions-renderer.component";
 import { NamespaceStatusRendererComponent } from "./renderer/namespace-status-renderer.component";
+import { NamespaceOffloadingRendererComponent } from "./renderer/namespace-offloading-renderer.component";
 @Component({
   selector: '[namespace-table]',
   templateUrl: './namespace-table.component.html',
@@ -37,6 +38,7 @@ export class NamespaceTableComponent implements OnInit {
     this.columnDefs = [
       { headerValueGetter: () => this.translateService.translate("namespaces.nameLabel"), field: 'name' },
       { headerValueGetter: () => this.translateService.translate("namespaces.statusLabel"), field: 'status', cellRenderer: NamespaceStatusRendererComponent },
+      { headerValueGetter: () => this.translateService.translate("namespaces.offloadingLabel"), field: 'offloading', cellRenderer: NamespaceOffloadingRendererComponent },
       { cellStyle: { "display": "flex" }, field: '', cellRenderer: NamespaceActionsRendererComponent, sortable: false, filter: false },
     ];
   }

--- a/frontend/src/app/shared/components/namespace-table/renderer/namespace-offloading-renderer.component.ts
+++ b/frontend/src/app/shared/components/namespace-table/renderer/namespace-offloading-renderer.component.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { Component } from "@angular/core";
+import { TranslocoService } from '@jsverse/transloco';
 import { ICellRendererAngularComp } from "ag-grid-angular";
 import { ICellRendererParams } from 'ag-grid-community';
 
@@ -31,7 +32,7 @@ import { ICellRendererParams } from 'ag-grid-community';
 export class NamespaceOffloadingRendererComponent implements ICellRendererAngularComp {
     public data!: any;
 
-    constructor() {
+    constructor(private translocoService: TranslocoService) {
     }
 
     agInit(params: ICellRendererParams<any>): void {
@@ -45,19 +46,17 @@ export class NamespaceOffloadingRendererComponent implements ICellRendererAngula
     getClass(policy?: string) {
         switch (policy) {
             case 'LocalAndRemote': return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300';
-            case 'LocalOnly': return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300';
+            case 'Local': return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300';
             case 'Remote': return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300';
             default: return 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-300';
         }
     }
 
     getDisplay(policy?: string) {
-        switch (policy) {
-            case 'LocalAndRemote': return 'Local and remote';
-            case 'LocalOnly': return 'Local only';
-            case 'Remote': return 'Remote only';
-            default: return '—';
+        if (['LocalAndRemote', 'Local', 'Remote'].includes(policy || '')) {
+            return this.translocoService.translate(`clusters.offloadingStrategy.strategy${policy}`);
         }
+        return '-';
     }
 
 }

--- a/frontend/src/app/shared/components/namespace-table/renderer/namespace-offloading-renderer.component.ts
+++ b/frontend/src/app/shared/components/namespace-table/renderer/namespace-offloading-renderer.component.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2025 ArubaKube S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component } from "@angular/core";
+import { ICellRendererAngularComp } from "ag-grid-angular";
+import { ICellRendererParams } from 'ag-grid-community';
+
+@Component({
+    selector: 'namespace-offloading-renderer',
+    template: `
+<span [ngClass]="getClass(data?.offloading?.podOffloadingStrategy)"
+      class="text-xs font-medium mr-2 px-2.5 py-0.5 rounded">
+    {{ getDisplay(data?.offloading?.podOffloadingStrategy) }}
+</span>
+  `,
+})
+
+
+export class NamespaceOffloadingRendererComponent implements ICellRendererAngularComp {
+    public data!: any;
+
+    constructor() {
+    }
+
+    agInit(params: ICellRendererParams<any>): void {
+        this.data = params.data;
+    }
+
+    refresh() {
+        return false;
+    }
+
+    getClass(policy?: string) {
+        switch (policy) {
+            case 'LocalAndRemote': return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300';
+            case 'LocalOnly': return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300';
+            case 'Remote': return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300';
+            default: return 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-300';
+        }
+    }
+
+    getDisplay(policy?: string) {
+        switch (policy) {
+            case 'LocalAndRemote': return 'Local and remote';
+            case 'LocalOnly': return 'Local only';
+            case 'Remote': return 'Remote only';
+            default: return '—';
+        }
+    }
+
+}

--- a/frontend/src/app/shared/components/namespace-table/renderer/namespace-offloading-renderer.component.ts
+++ b/frontend/src/app/shared/components/namespace-table/renderer/namespace-offloading-renderer.component.ts
@@ -21,8 +21,8 @@ import { ICellRendererParams } from 'ag-grid-community';
 @Component({
     selector: 'namespace-offloading-renderer',
     template: `
-<span [ngClass]="getClass(data?.offloading?.podOffloadingStrategy)"
-      class="text-xs font-medium mr-2 px-2.5 py-0.5 rounded">
+<span
+      class="text-xs font-medium">
     {{ getDisplay(data?.offloading?.podOffloadingStrategy) }}
 </span>
   `,
@@ -41,15 +41,6 @@ export class NamespaceOffloadingRendererComponent implements ICellRendererAngula
 
     refresh() {
         return false;
-    }
-
-    getClass(policy?: string) {
-        switch (policy) {
-            case 'LocalAndRemote': return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300';
-            case 'Local': return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300';
-            case 'Remote': return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300';
-            default: return 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-300';
-        }
     }
 
     getDisplay(policy?: string) {

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -40,6 +40,9 @@ import {
 import {
   NamespaceStatusRendererComponent
 } from "./components/namespace-table/renderer/namespace-status-renderer.component";
+import {
+  NamespaceOffloadingRendererComponent
+} from "./components/namespace-table/renderer/namespace-offloading-renderer.component";
 import { PodTableComponent } from "./components/pod-table/pod-table.component";
 import { PodLabelsRendererComponent } from "./components/pod-table/renderer/pod-labels-renderer.component";
 import { PodStatusRendererComponent } from "./components/pod-table/renderer/pod-status-renderer.component";
@@ -51,6 +54,7 @@ import { PodStatusRendererComponent } from "./components/pod-table/renderer/pod-
     NamespaceTableComponent,
     NamespaceActionsRendererComponent,
     NamespaceStatusRendererComponent,
+    NamespaceOffloadingRendererComponent,
     PodTableComponent,
     PodLabelsRendererComponent,
     PodStatusRendererComponent,
@@ -87,6 +91,7 @@ import { PodStatusRendererComponent } from "./components/pod-table/renderer/pod-
     ClusterActionsRendererComponent,
     NamespaceActionsRendererComponent,
     NamespaceStatusRendererComponent,
+    NamespaceOffloadingRendererComponent,
     PodTableComponent,
     PodLabelsRendererComponent,
     PodStatusRendererComponent,

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -75,6 +75,7 @@
     "offloadedNamespaces": "Offloaded namespaces",
     "nameLabel": "Name",
     "statusLabel": "Status",
+    "offloadingLabel": "Offloading policy",
     "showPodsAction": "Show pods in the namespace",
     "podsOnNamespace": "Pods on offloaded namespace",
     "offloadingConfirmQuestion": "Do you want to offload this namespace?",

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -69,6 +69,11 @@
       "sharedMemory": "Shared memory",
       "sharedPods": "Shared pods",
       "sharedEphemeralStorage": "Shared ephemeral storage"
+    },
+    "offloadingStrategy": {
+      "strategyLocalAndRemote": "Local and remote",
+      "strategyLocal": "Local",
+      "strategyRemote": "Remote"
     }
   },
   "namespaces": {

--- a/frontend/src/assets/i18n/it.json
+++ b/frontend/src/assets/i18n/it.json
@@ -69,6 +69,11 @@
       "sharedMemory": "Memoria condivisa",
       "sharedPods": "Pod condivisi",
       "sharedEphemeralStorage": "Storage effimero condiviso"
+    },
+    "offloadingStrategy": {
+      "strategyLocalAndRemote": "Locale e remoto",
+      "strategyLocal": "Locale",
+      "strategyRemote": "Remoto"
     }
   },
   "namespaces": {

--- a/frontend/src/assets/i18n/it.json
+++ b/frontend/src/assets/i18n/it.json
@@ -75,6 +75,7 @@
     "offloadedNamespaces": "Namespace scaricati",
     "nameLabel": "Nome",
     "statusLabel": "Stato",
+    "offloadingLabel": "Criterio di offload",
     "showPodsAction": "Mostra i pod nel namespace",
     "podsOnNamespace": "Pod nel namespace scaricato",
     "offloadingConfirmQuestion": "Vuoi scaricare questo namespace?",


### PR DESCRIPTION
Added a "status" tag to display the offloading policy.

- Used the same tag style currently applied to the "status" column.
- Color coding:
  - Green: Local and Remote offloading
  - Yellow: Local only offloading
  - Blue: Remote offloading
  - Grey: Fallback / default
