### PR TITLE
Started dev on gpu support for clusters (issue#16)

### DIFF
--- a/backend/pkg/server/models/common.go
+++ b/backend/pkg/server/models/common.go
@@ -22,6 +22,7 @@ import (
 type Resources struct {
 	CPU              resource.Quantity `json:"cpu"`
 	Memory           resource.Quantity `json:"memory"`
+	GPU              resource.Quantity `json:"gpu"`
 	Pods             resource.Quantity `json:"pods"`
 	EphemeralStorage resource.Quantity `json:"ephemeralStorage"`
 }

--- a/backend/pkg/utils/getters/clusters.go
+++ b/backend/pkg/utils/getters/clusters.go
@@ -16,6 +16,7 @@ package getters
 
 import (
 	"context"
+	"strings"
 
 	authv1beta1 "github.com/liqotech/liqo/apis/authentication/v1beta1"
 	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
@@ -99,9 +100,17 @@ func parseVirtualNode(ctx context.Context, cl client.Client, vnode *offloadingv1
 		if err := cl.Get(ctx, client.ObjectKey{Name: nodeName}, &node); err != nil {
 			return models.Node{}, err
 		}
+
+		var gpuCapacity resource.Quantity
+		for key, val := range node.Status.Capacity {
+			if strings.Contains(string(key), "gpu") {
+				gpuCapacity.Add(val)
+			}
+		}
 		capacity = models.Resources{
 			CPU:              *node.Status.Capacity.Cpu(),
 			Memory:           *node.Status.Capacity.Memory(),
+			GPU:              gpuCapacity,
 			Pods:             *node.Status.Capacity.Pods(),
 			EphemeralStorage: *node.Status.Capacity.StorageEphemeral(),
 		}
@@ -183,6 +192,7 @@ func getResourcesFromResourceSlice(resSlices []authv1beta1.ResourceSlice) models
 	// Initialize the total offered resources to 0
 	cpuTot := resource.NewQuantity(0, resource.DecimalSI)
 	memTot := resource.NewQuantity(0, resource.BinarySI)
+	gpuTot := resource.NewQuantity(0, resource.DecimalSI)
 	podsTot := resource.NewQuantity(0, resource.DecimalSI)
 	storageTot := resource.NewQuantity(0, resource.BinarySI)
 
@@ -194,11 +204,18 @@ func getResourcesFromResourceSlice(resSlices []authv1beta1.ResourceSlice) models
 		memTot.Add(*resSlices[i].Status.Resources.Memory())
 		podsTot.Add(*resSlices[i].Status.Resources.Pods())
 		storageTot.Add(*resSlices[i].Status.Resources.StorageEphemeral())
+
+		for key, val := range resSlices[i].Status.Resources {
+			if strings.Contains(string(key), "gpu") {
+				gpuTot.Add(val)
+			}
+		}
 	}
 
 	return models.Resources{
 		CPU:              *cpuTot,
 		Memory:           *memTot,
+		GPU:              *gpuTot,
 		Pods:             *podsTot,
 		EphemeralStorage: *storageTot,
 	}

--- a/frontend/src/app/modules/cluster/models/cluster.ts
+++ b/frontend/src/app/modules/cluster/models/cluster.ts
@@ -23,6 +23,6 @@ export interface Cluster {
   authenticationStatus?: string;
   offloadingStatus?: string;
   networkLatency?: string;
-  resourcesOffered?: { cpu: string, memory: string, pods: string, "ephemeralStorage": string };
-  resourcesAcquired?: { cpu: string, memory: string, pods: string, "ephemeralStorage": string };
+  resourcesOffered?: { cpu: string, memory: string, gpu:string, pods: string, "ephemeralStorage": string };
+  resourcesAcquired?: { cpu: string, memory: string, gpu:string, pods: string, "ephemeralStorage": string };
 }

--- a/frontend/src/app/modules/cluster/models/node.ts
+++ b/frontend/src/app/modules/cluster/models/node.ts
@@ -17,6 +17,7 @@
 export interface Resources {
     cpu: string;
     memory: string;
+    gpu: string;
     pods: string;
     ephemeralStorage: string;
 }

--- a/frontend/src/app/modules/cluster/pages/cluster-detail/cluster-detail.component.html
+++ b/frontend/src/app/modules/cluster/pages/cluster-detail/cluster-detail.component.html
@@ -117,6 +117,14 @@
 
         <div>
           <div class="label">
+            <i class="fa-solid fa-display"></i>
+            {{ t('clusters.details.sharedGPU') }}
+          </div>
+          {{ (cluster?.resourcesAcquired || {}).gpu || '0' }}
+        </div>
+
+        <div>
+          <div class="label">
             <i class="fa-solid fa-box-open"></i>
             {{ t('clusters.details.sharedPods') }}
           </div>
@@ -150,6 +158,14 @@
             {{ t('clusters.details.sharedMemory') }}
           </div>
           {{ (cluster?.resourcesOffered || {}).memory || '0' }}
+        </div>
+
+        <div>
+          <div class="label">
+            <i class="fa-solid fa-display"></i>
+            {{ t('clusters.details.sharedGPU') }}
+          </div>
+          {{ (cluster?.resourcesOffered || {}).gpu || '0' }}
         </div>
 
         <div>

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -68,6 +68,7 @@
       "resourcesOffered": "Resources offered",
       "sharedCPU": "Shared CPU",
       "sharedMemory": "Shared memory",
+      "sharedGPU": "Shared GPU",
       "sharedPods": "Shared pods",
       "sharedEphemeralStorage": "Shared ephemeral storage"
     },

--- a/frontend/src/assets/i18n/it.json
+++ b/frontend/src/assets/i18n/it.json
@@ -68,6 +68,7 @@
       "resourcesOffered": "Risorse offerte",
       "sharedCPU": "CPU condivisa",
       "sharedMemory": "Memoria condivisa",
+      "sharedGPU": "GPU condivisa",
       "sharedPods": "Pod condivisi",
       "sharedEphemeralStorage": "Storage effimero condiviso"
     },


### PR DESCRIPTION
This PR introduces support for displaying GPU resources (both acquired and offered) within the cluster details, adopting a vendor agnostic approach (it dynamically detects any extended resource containing the "gpu" string (e.g., nvidia.com/gpu, gpu.intel.com/i915, etc.), ensuring compatibility across different hardware providers).

The logic has been verified by manually mocking GPU resources in the ResourceSlice status within a KinD environment, since I do not have any GPU available.

I am open to any kind of feedback.
Have a nice day!