### PR TITLE
fix(helm): add RBAC for configmaps, deployments, and ipam networks

### DIFF
--- a/deployments/liqo-dashboard/templates/rbac.yaml
+++ b/deployments/liqo-dashboard/templates/rbac.yaml
@@ -41,11 +41,26 @@ rules:
   - get
   - list
 - apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - "ipam.liqo.io"
+  resources:
+  - networks
+  verbs:
+  - get
+  - list
+- apiGroups:
   - ""
   resources:
   - namespaces
   - pods
   - nodes
+  - configmaps
   verbs:
   - get
   - list


### PR DESCRIPTION
## What

Adds the missing RBAC permissions to the Helm chart's ClusterRole so the backend can read the resources it needs out-of-the-box.

## Why

The backend requires access to a few resources that weren't covered by the chart's ClusterRole, so users currently have to patch the ClusterRole manually after install (via `kubectl patch`) for the dashboard to work fully.

## Changes

Added the following rules to `deployments/liqo-dashboard/templates/rbac.yaml`:

  | apiGroup        | resources     | verbs              |
  | --------------- | ------------- | ------------------ |
  | `""` (core)     | `configmaps`  | get, list, watch   |
  | `apps`          | `deployments` | get, list          |
  | `ipam.liqo.io`  | `networks`    | get, list          |

`configmaps` was folded into the existing core (`""`) rule since the verbs match;
`deployments` and `networks` are new rule blocks.

## Testing

- `helm lint` passes.
- `helm template` renders the ClusterRole with all three new rules present.

## Notes

Existing installations need a `helm upgrade` to pick up the new permissions, after which the manual `kubectl patch` workarounds are no longer required.